### PR TITLE
Add link to github repositories for forms

### DIFF
--- a/docs/Resources-DetailForm.md
+++ b/docs/Resources-DetailForm.md
@@ -289,3 +289,11 @@ title: Detail Form Templates
       </tr>
   </table>
 </div>
+
+<div markdown="1" class = "tips">
+
+**More**
+
+You can find more detail form template on [github](https://github.com/search?q=topic%3A4d-for-ios-form-detail).
+
+</div>


### PR DESCRIPTION
## suggestion 

I add topics link at the bottom of https://developer.4d.com/4d-for-ios/docs/en/custom-detailform-templates.html
But you can change where you want to add it

Then same things could be done for list form and formatters